### PR TITLE
Redirecting the cv_imshow link for a patched version

### DIFF
--- a/docs/software/gdb.md
+++ b/docs/software/gdb.md
@@ -57,7 +57,7 @@ For a more exhaustive list, see the GDB manpages (`man gdb`) or any online tutor
 | `<Enter>`                    | repeats the last command                 |                                                                                             |
 | `u #`                        | continue Until line `#`                  | `#` = the line number in the current file                                                   |
 | `ref`                        | REFresh the screen                       | in case of some visual problems                                                             |
-| `cv_imshow #`                | display an OpenCV image `#`              | requires [a plugin](https://github.com/renatoGarcia/gdb-imshow) (installed with `uav_core`) |
+| `cv_imshow #`                | display an OpenCV image `#`              | requires [a plugin](https://github.com/ViktorWalter/gdb-imshow) (installed with `uav_core`) |
 | `~/.gdbinit` file            | put pre-start settings in here           | an example is in the file                                                                   |
 
 ## Advanced debugging


### PR DESCRIPTION
I am redirecting the link for the cv_imshow gdb plugin to my fork that fixes a bug apparently affecting some versions of the python PIL library used therein. This bug prevented displaying of images if the .show() function was not given a window title. I suggest changing the version of the gdb plugin installed with uav_core to this one too.